### PR TITLE
Make Mario physics more realistic

### DIFF
--- a/src/Mario.purs
+++ b/src/Mario.purs
@@ -35,16 +35,16 @@ leftKeyCode = 37 -- left arrow
 
 groundHeight = 40 -- px
 
-gravity = 0.3 -- px / frame^2
+gravity = 0.2 -- px / frame^2
 
-jumpSpeed = 6 -- px / frame
-maxMoveSpeed = 4 -- px / frame
+jumpSpeed = 3.9375 -- px / frame
+maxMoveSpeed = 2.5 -- px / frame
 
-groundAccel = 0.06 -- px / frame^2
-airAccel = 0.04 -- px / frame^2
+groundAccel = 0.04296875 -- px / frame^2
+airAccel = 0.04296875 -- px / frame^2
 
-groundFriction = 0.15 -- px / frame^2
-airFriction = 0.02 -- px / frame^2
+groundFriction = 0.1 -- px / frame^2
+airFriction = 0.0 -- px / frame^2
 
 
 marioSpriteUrl :: Verb -> Direction -> String


### PR DESCRIPTION
Bro, your Mario physics were insane unless this was supposed to be a moon level from The Six Golden Coins on Gameboy.

![marioland2_08](https://cloud.githubusercontent.com/assets/896692/4511019/568b5c9c-4b30-11e4-9f14-e13b690952c9.png)

Pro-tip: For ultimate awesomeness, jumpSpeed should have three different increments instead of just one. The jump speed you use should be based on Mario's horizontal speed at take off.

(I'll show myself out now.)
